### PR TITLE
feat: global key bind option, invocable script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ set -g @ephemeral-buoyshell-key "F"
 # Change the global toggle keybinding (disabled by default)
 set -g @buoyshell-global-key "C-M-f"
 # Change the global ephemeral keybinding (disabled by default)
-set -g @ephemeral-buoyshell-global-key "C-M-F"
+set -g @ephemeral-buoyshell-global-key "C-M-n"
 
 # Set buoyshell title
 set-option -g @buoyshell-title ''

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ You can customize the plugin behavior by setting these options in your `~/.tmux.
 set -g @buoyshell-key "f"
 # Change the ephemeral buoyshell keybinding (default: F)
 set -g @ephemeral-buoyshell-key "F"
+# Change the global toggle keybinding (disabled by default)
+set -g @buoyshell-global-key "C-M-f"
+# Change the global ephemeral keybinding
+set -g @ephemeral-buoyshell-global-key "C-M-F"
 
 # Set buoyshell title
 set-option -g @buoyshell-title ''

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ set -g @buoyshell-key "f"
 set -g @ephemeral-buoyshell-key "F"
 # Change the global toggle keybinding (disabled by default)
 set -g @buoyshell-global-key "C-M-f"
-# Change the global ephemeral keybinding
+# Change the global ephemeral keybinding (disabled by default)
 set -g @ephemeral-buoyshell-global-key "C-M-F"
 
 # Set buoyshell title

--- a/buoyshell.tmux
+++ b/buoyshell.tmux
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 buoy_key=$(tmux show-option -gv '@buoyshell-key')
 buoy_global_key=$(tmux show-option -gv '@buoyshell-global-key')
 ephemeral_buoy_key=$(tmux show-option -gv '@ephemeral-buoyshell-key')
 ephemeral_buoy_global_key=$(tmux show-option -gv '@ephemeral-buoyshell-global-key')
-buoy_session="_buoy-session"
-ephemeral_buoy_session="_ephemeral-buoy-session"
 
 : "${buoy_key:=f}"
 : "${ephemeral_buoy_key:=F}"

--- a/buoyshell.tmux
+++ b/buoyshell.tmux
@@ -1,42 +1,18 @@
 #!/usr/bin/env bash
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 buoy_key=$(tmux show-option -gv '@buoyshell-key')
+buoy_global_key=$(tmux show-option -gv '@buoyshell-global-key')
 ephemeral_buoy_key=$(tmux show-option -gv '@ephemeral-buoyshell-key')
+ephemeral_buoy_global_key=$(tmux show-option -gv '@ephemeral-buoyshell-global-key')
 buoy_session="_buoy-session"
 ephemeral_buoy_session="_ephemeral-buoy-session"
 
 : "${buoy_key:=f}"
 : "${ephemeral_buoy_key:=F}"
 
-# Persistent Buoyshell
-# tmux bind-key "$buoy_key" if-shell -F "#{==:#{client_session},$buoy_session}" \
-#     "detach-client" \
-#     "run-shell '$CURRENT_DIR/scripts/buoy.sh'"
-# 
-# # Ephemeral Buoyshell
-# tmux bind-key "$ephemeral_buoy_key" if-shell -F "#{==:#{client_session},$ephemeral_buoy_session}" \
-#     "detach-client" \
-#     "run-shell '$CURRENT_DIR/scripts/ephemeral_buoy.sh'"
+tmux bind-key "$buoy_key" run-shell ". ~/.tmux/plugins/tmux-buoyshell/scripts/buoy_invoke.sh standard"
+tmux bind-key "$ephemeral_buoy_key" run-shell ". ~/.tmux/plugins/tmux-buoyshell/scripts/buoy_invoke.sh ephemeral"
 
-# Universal detach or invoke for Persistent Buoy
-tmux bind-key "$buoy_key" run-shell " \
-    current_session=\$(tmux display-message -p '#{client_session}'); \
-    if [[ \"\$current_session\" == \"$ephemeral_buoy_session\" ]]; then \
-        tmux detach-client -s \"$ephemeral_buoy_session\"; \
-    elif [[ \"\$current_session\" == \"$buoy_session\" ]]; then \
-        tmux detach-client -s \"$buoy_session\"; \
-    else \
-        '$CURRENT_DIR/scripts/buoy.sh'; \
-    fi"
-
-# Universal detach or invoke for Ephemeral Buoy
-tmux bind-key "$ephemeral_buoy_key" run-shell " \
-    current_session=\$(tmux display-message -p '#{client_session}'); \
-    if [[ \"\$current_session\" == \"$buoy_session\" ]]; then \
-        tmux detach-client -s \"$buoy_session\"; \
-    elif [[ \"\$current_session\" == \"$ephemeral_buoy_session\" ]]; then \
-        tmux detach-client -s \"$ephemeral_buoy_session\"; \
-        tmux kill-session -t \"$ephemeral_buoy_session\"; \
-    else \
-        '$CURRENT_DIR/scripts/ephemeral_buoy.sh'; \
-    fi"
+# global key config
+[[ -n $buoy_global_key ]] && tmux bind-key -n "$buoy_global_key" run-shell ". ~/.tmux/plugins/tmux-buoyshell/scripts/buoy_invoke.sh standard"
+[[ -n $ephemeral_buoy_global_key ]] && tmux bind-key -n "$ephemeral_buoy_global_key" run-shell ". ~/.tmux/plugins/tmux-buoyshell/scripts/buoy_invoke.sh ephemeral"

--- a/scripts/buoy_invoke.sh
+++ b/scripts/buoy_invoke.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
-mode=$1
+mode=$1 # standard or ephemeral
 
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 buoy_key=$(tmux show-option -gv '@buoyshell-key')
 ephemeral_buoy_key=$(tmux show-option -gv '@ephemeral-buoyshell-key')
 buoy_session="_buoy-session"
 ephemeral_buoy_session="_ephemeral-buoy-session"
-
-: "${buoy_key:=f}"
-: "${ephemeral_buoy_key:=F}"
 
 # Universal detach or invoke for Persistent Buoy
 if [[ "standard" == "${mode}" ]]; then

--- a/scripts/buoy_invoke.sh
+++ b/scripts/buoy_invoke.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+mode=$1
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+buoy_key=$(tmux show-option -gv '@buoyshell-key')
+ephemeral_buoy_key=$(tmux show-option -gv '@ephemeral-buoyshell-key')
+buoy_session="_buoy-session"
+ephemeral_buoy_session="_ephemeral-buoy-session"
+
+: "${buoy_key:=f}"
+: "${ephemeral_buoy_key:=F}"
+
+# Universal detach or invoke for Persistent Buoy
+if [[ "standard" == "${mode}" ]]; then
+  current_session=$(tmux display-message -p '#{client_session}')
+  if [[ "$current_session" == "$ephemeral_buoy_session" ]]; then
+      tmux detach-client -s "$ephemeral_buoy_session"
+  elif [[ "$current_session" == "$buoy_session" ]]; then
+      tmux detach-client -s "$buoy_session"
+  else
+      . ~/.tmux/plugins/tmux-buoyshell/scripts/buoy.sh
+  fi
+# Universal detach or invoke for Ephemeral Buoy
+elif [[ "ephemeral" == "${mode}" ]]; then
+  current_session=$(tmux display-message -p '#{client_session}')
+  if [[ "$current_session" == "$buoy_session" ]]; then
+      tmux detach-client -s "$buoy_session"
+  elif [[ "$current_session" == "$ephemeral_buoy_session" ]]; then
+      tmux detach-client -s "$ephemeral_buoy_session"
+      tmux kill-session -t "$ephemeral_buoy_session"
+  else
+      . ~/.tmux/plugins/tmux-buoyshell/scripts/ephemeral_buoy.sh
+  fi
+fi


### PR DESCRIPTION
Adds global key bind options (disabled by default).

Adds the ability to invoke buoyshell with user scripts for greater flexibility:
`bind-key -T prefix F run-shell ". ~/.tmux/plugins/tmux-buoyshell/scripts/buoy_invoke.sh ephemeral; echo hello world"`