### PR TITLE
Faster shpell-casting: unify tmux calls and optimize IPC flow

### DIFF
--- a/grimoire.tmux
+++ b/grimoire.tmux
@@ -43,7 +43,7 @@ current_path=${env_line#PATH=}
 
 # Idempotent PATH update: only append if not already present
 if [[ ":$current_path:" != *":$PLUGIN_DIR/bin:"* ]]; then
-  tmux set-environment -g PATH "$PLUGIN_DIR/bin:$current_path" 2>/dev/null
+    tmux set-environment -g PATH "$PLUGIN_DIR/bin:$current_path" 2>/dev/null
 fi
 
 # Default keybindings (prefix + f/F/C/H) - overridden by user options
@@ -55,15 +55,15 @@ grimoire_helper_key="H"
 # Batch keybindings and options via heredoc to minimize tmux server calls
 # Wrapped in command group with || true to prevent TPM source failures (returns exit 0 even if tmux server unavailable)
 { tmux <<TMUX
-bind-key "$grimoire_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh standard"
-bind-key "$ephemeral_grimoire_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh
-ephemeral"
-bind-key "$grimoire_kill_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh kill"
-bind-key "$grimoire_helper_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh
-ephemeral grimoire '$PLUGIN_DIR/bin/logo'"
-set -g @shpell-grimoire-color "#c6b7ee"
-set -g @shpell-grimoire-width "45%"
-set -g @shpell-grimoire-height "55%"
-set -g @shpell-grimoire-position "top-center"
+    bind-key "$grimoire_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh standard"
+    bind-key "$ephemeral_grimoire_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh
+    ephemeral"
+    bind-key "$grimoire_kill_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh kill"
+    bind-key "$grimoire_helper_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh
+    ephemeral grimoire '$PLUGIN_DIR/bin/logo'"
+    set -g @shpell-grimoire-color "#c6b7ee"
+    set -g @shpell-grimoire-width "45%"
+    set -g @shpell-grimoire-height "55%"
+    set -g @shpell-grimoire-position "top-center"
 TMUX
 } 2>/dev/null || true

--- a/grimoire.tmux
+++ b/grimoire.tmux
@@ -1,29 +1,69 @@
 #!/usr/bin/env bash
-grimoire_key=$(tmux show-option -gv '@grimoire-key')
-ephemeral_grimoire_key=$(tmux show-option -gv '@ephemeral-grimoire-key')
-grimoire_kill_key=$(tmux show-option -gv '@grimoire-kill-key')
 
+: <<'TMUX_GRIMOIRE'
+
+   ╔═══════════════════════════════════════════════════════════════╗
+   ║                                                               ║
+   ║  ████████╗███╗   ███╗██╗   ██╗██╗   ██╗                       ║
+   ║  ╚══██╔══╝████╗ ████║██║   ██║ ██╗ ██╔╝                       ║
+   ║     ██║   ██╔████╔██║██║   ██║  ████╔╝                        ║
+   ║     ██║   ██║╚██╔╝██║██║   ██║ ██╔═██╗                        ║
+   ║     ██║   ██║ ╚═╝ ██║╚██████╔╝██╔╝  ██╗                       ║
+   ║     ╚═╝   ╚═╝     ╚═╝ ╚═════╝ ╚═╝   ╚═╝                       ║
+   ║                                                               ║
+   ║   ██████╗ ██████╗ ██╗███╗   ███╗ ██████╗ ██╗██████╗ ███████╗  ║
+   ║  ██╔════╝ ██╔══██╗██║████╗ ████║██╔═══██╗██║██╔══██╗██╔════╝  ║
+   ║  ██║  ███╗██████╔╝██║██╔████╔██║██║   ██║██║██████╔╝█████╗    ║
+   ║  ██║   ██║██╔══██╗██║██║╚██╔╝██║██║   ██║██║██╔══██╗██╔══╝    ║
+   ║  ╚██████╔╝██║  ██║██║██║ ╚═╝ ██║╚██████╔╝██║██║  ██║███████╗  ║
+   ║   ╚═════╝ ╚═╝  ╚═╝╚═╝╚═╝     ╚═╝ ╚═════╝ ╚═╝╚═╝  ╚═╝╚══════╝  ║
+   ║                                                               ║ 
+   ╚═══════════════════════════════════════════════════════════════╝
+
+   Bash trick: Using : (no-op) with heredoc creates a comment block
+   that bash parses but doesn't execute - perfect for ASCII art
+
+TMUX_GRIMOIRE
+
+# User-configurable keybindings 
+# set -g @grimoire-key '' 
+# set -g @ephemeral-grimoire-key ''
+# set -g @grimoire-kill-key ''
+grimoire_key=$(tmux show-option -gqv '@grimoire-key')
+ephemeral_grimoire_key=$(tmux show-option -gqv '@ephemeral-grimoire-key')
+grimoire_kill_key=$(tmux show-option -gqv '@grimoire-kill-key')
+
+# Resolve plugin directory for script paths
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-current_path=$(tmux show-environment -g PATH | cut -d= -f2-)
 
-# Append only if not present, to prevent adding to PATH multiple times
+# Extend tmux PATH with plugin bin/ directory (parameter expansion avoids subprocess overhead)
+env_line=$(tmux show-environment -g PATH 2>/dev/null || true)
+current_path=${env_line#PATH=}
+: "${current_path:=$PATH}"
+
+# Idempotent PATH update: only append if not already present
 if [[ ":$current_path:" != *":$PLUGIN_DIR/bin:"* ]]; then
-  tmux set-environment -g PATH "$PLUGIN_DIR/bin:$current_path"
+  tmux set-environment -g PATH "$PLUGIN_DIR/bin:$current_path" 2>/dev/null
 fi
 
+# Default keybindings (prefix + f/F/C/H) - overridden by user options
 : "${grimoire_key:=f}"
 : "${ephemeral_grimoire_key:=F}"
 : "${grimoire_kill_key:=C}"
 grimoire_helper_key="H"
 
-tmux bind-key "$grimoire_key" run-shell "$HOME/.tmux/plugins/tmux-grimoire/scripts/cast_shpell.sh standard"
-tmux bind-key "$ephemeral_grimoire_key" run-shell "$HOME/.tmux/plugins/tmux-grimoire/scripts/cast_shpell.sh ephemeral"
-tmux bind-key "$grimoire_kill_key" run-shell "$HOME/.tmux/plugins/tmux-grimoire/scripts/cast_shpell.sh kill"
-
-tmux bind-key "$grimoire_helper_key" \
-  run-shell "$HOME/.tmux/plugins/tmux-grimoire/scripts/cast_shpell.sh ephemeral grimoire '$HOME/.tmux/plugins/tmux-grimoire/bin/logo'"
-
-tmux set -g @shpell-grimoire-color "#c6b7ee"
-tmux set -g @shpell-grimoire-width "45%"
-tmux set -g @shpell-grimoire-height "55%"
-tmux set -g @shpell-grimoire-position "top-center"
+# Batch keybindings and options via heredoc to minimize tmux server calls
+# Wrapped in command group with || true to prevent TPM source failures (returns exit 0 even if tmux server unavailable)
+{ tmux <<TMUX
+bind-key "$grimoire_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh standard"
+bind-key "$ephemeral_grimoire_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh
+ephemeral"
+bind-key "$grimoire_kill_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh kill"
+bind-key "$grimoire_helper_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh
+ephemeral grimoire '$PLUGIN_DIR/bin/logo'"
+set -g @shpell-grimoire-color "#c6b7ee"
+set -g @shpell-grimoire-width "45%"
+set -g @shpell-grimoire-height "55%"
+set -g @shpell-grimoire-position "top-center"
+TMUX
+} 2>/dev/null || true

--- a/grimoire.tmux
+++ b/grimoire.tmux
@@ -25,16 +25,25 @@
 
 TMUX_GRIMOIRE
 
-# User-configurable keybindings 
-# set -g @grimoire-key '' 
-# set -g @ephemeral-grimoire-key ''
-# set -g @grimoire-kill-key ''
-grimoire_key=$(tmux show-option -gqv '@grimoire-key')
-ephemeral_grimoire_key=$(tmux show-option -gqv '@ephemeral-grimoire-key')
-grimoire_kill_key=$(tmux show-option -gqv '@grimoire-kill-key')
-
 # Resolve plugin directory for script paths
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# SINGLE-IPC OPTION FETCH: batch all tmux option reads into one display-message call
+i=0
+while IFS= read -r line; do
+    opts[$i]="$line"
+    ((i++))
+done < <(tmux display-message -p '#{?@grimoire-key,#{@grimoire-key},}
+#{?@ephemeral-grimoire-key,#{@ephemeral-grimoire-key},}
+#{?@grimoire-kill-key,#{@grimoire-kill-key},}')
+
+# User-configurable keybindings
+# set -g @grimoire-key ''
+# set -g @ephemeral-grimoire-key ''
+# set -g @grimoire-kill-key ''
+grimoire_key=${opts[0]}
+ephemeral_grimoire_key=${opts[1]}
+grimoire_kill_key=${opts[2]}
 
 # Extend tmux PATH with plugin bin/ directory (parameter expansion avoids subprocess overhead)
 env_line=$(tmux show-environment -g PATH 2>/dev/null || true)

--- a/grimoire.tmux
+++ b/grimoire.tmux
@@ -53,7 +53,8 @@ fi
 grimoire_helper_key="H"
 
 # Batch keybindings and options via heredoc to minimize tmux server calls
-# Wrapped in command group with || true to prevent TPM source failures (returns exit 0 even if tmux server unavailable)
+# Wrapped in command group with || true to prevent TPM source failures
+# (returns exit 0 even if tmux server unavailable)
 { tmux <<TMUX
     bind-key "$grimoire_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh standard"
     bind-key "$ephemeral_grimoire_key" run-shell "$PLUGIN_DIR/scripts/cast_shpell.sh

--- a/scripts/shpell.sh
+++ b/scripts/shpell.sh
@@ -1,24 +1,22 @@
 #!/usr/bin/env bash
 
-current_session=$(tmux display-message -p '#{client_session}')
-current_client=$(tmux display-message -p '#{client_name}')
-original_mouse_setting=$(tmux show-option -gv mouse)
-grimoire_width=$(tmux show-option -gv '@grimoire-width')
-grimoire_height=$(tmux show-option -gv '@grimoire-height')
-grimoire_position=$(tmux show-option -gv "@grimoire-position")
-grimoire_window_title=$(tmux show-option -gv '@grimoire-title')
-grimoire_window_color=$(tmux show-option -gv '@grimoire-color')
 grimoire_session="_shpell-session"
 
 custom_shpell=$1
 grimoire_custom_command=$2
 replay_flag=$3
 
+grimoire_width=$(tmux show-option -gqv '@grimoire-width')
+grimoire_height=$(tmux show-option -gqv '@grimoire-height')
+grimoire_position=$(tmux show-option -gqv "@grimoire-position")
+grimoire_window_title=$(tmux show-option -gqv '@grimoire-title')
+grimoire_window_color=$(tmux show-option -gqv '@grimoire-color')
+
 if [[ -n "$custom_shpell" ]]; then
-    custom_position=$(tmux show-option -gv "@shpell-${custom_shpell}-position" 2>/dev/null)
-    custom_width=$(tmux show-option -gv "@shpell-${custom_shpell}-width" 2>/dev/null)
-    custom_height=$(tmux show-option -gv "@shpell-${custom_shpell}-height" 2>/dev/null)
-    custom_color=$(tmux show-option -gv "@shpell-${custom_shpell}-color" 2>/dev/null)
+    custom_position=$(tmux show-option -gqv "@shpell-${custom_shpell}-position" 2>/dev/null)
+    custom_width=$(tmux show-option -gqv "@shpell-${custom_shpell}-width" 2>/dev/null)
+    custom_height=$(tmux show-option -gqv "@shpell-${custom_shpell}-height" 2>/dev/null)
+    custom_color=$(tmux show-option -gqv "@shpell-${custom_shpell}-color" 2>/dev/null)
 
     [[ -n "$custom_position" ]] && grimoire_position="$custom_position"
     [[ -n "$custom_width" ]] && grimoire_width="$custom_width"
@@ -48,45 +46,77 @@ grimoire_name="${grimoire_window_title:-}"
 shpell_name="${custom_shpell:-main}"
 popup_title="$grimoire_name| $shpell_name "
 
-session_dir=$(tmux display-message -t "$current_session" -p '#{pane_current_path}')
-window_exists=$(tmux list-windows -t "$current_session" -F "#{window_name}" | grep -x "$shpell_name" || echo "")
+# Working dir: active pane path (session) -> default-path -> $PWD
+session_dir=$(
+tmux display-message -p -t "${current_session:-}:" "#{pane_current_path}" 2>/dev/null \
+    || tmux show-option -gqv default-path 2>/dev/null \
+    || echo "$PWD"
+)
 
+# Session to operate on: client pane's session -> generic -> empty
+current_session=$(
+tmux display-message -p -t "${TMUX_PANE:-}" "#{session_name}" 2>/dev/null \
+    || tmux display-message -p "#{session_name}" 2>/dev/null \
+    || echo ""
+)
+
+# Probe if a window named $shpell_name exists in $current_session,
+# WITHOUT spawning grep/awk (pure Bash), and with exact string match.
+# We also strip any stray CRs just in case (some environments can inject them)
+window_exists=
+while IFS= read -r name; do
+    if [[ $name == "$shpell_name" ]]; then
+        window_exists=1
+        break
+    fi
+done < <(tmux list-windows -t "$current_session" -F '#{window_name}' 2>/dev/null | tr -d '\r')
+
+# --- Single batched tmux client invocation ---
+# TMUX='' unsets the client env var so this command talks to the server
+# (critical when running from inside tmux to avoid nesting client state).
+# We chain multiple subcommands with '\;' so the *same tmux client* performs
+# them sequentially and atomically: one process, one round-trip.
 TMUX='' tmux new-session -d -s "$grimoire_session" -n "$shpell_name" -c "$session_dir" \; \
     set-option -t "$grimoire_session" status off \; \
+    set-hook -u -t "$grimoire_session" client-detached \; \
+    set-hook -t "$grimoire_session" client-detached \
+    "run-shell 'tmux swap-window -s \"$grimoire_session:$shpell_name\" \
+        -t \"$current_session:$shpell_name\"; \
+        tmux kill-session -t \"$grimoire_session\"'"
 
-# Set detach hook
-tmux set-hook -u -t "$grimoire_session" client-detached
-tmux set-hook -t "$grimoire_session" client-detached \
-    "run-shell 'tmux swap-window -s \"$grimoire_session:$shpell_name\" -t \"$current_session:$shpell_name\"; tmux kill-session -t \"$grimoire_session\"'"
-
-if [[ -z "$window_exists" ]]; then
+if [[ -z "$window_exists" ]]; then # window does not exist yet in $current_session
     if [[ -n $grimoire_custom_command ]]; then
-        tmux send-keys -t "$grimoire_session:$shpell_name" "clear; bash -c \"${grimoire_custom_command//\"/\\\"}\"" Enter
+        tmux send-keys -t "$grimoire_session:$shpell_name" \
+            "clear; bash -c \"${grimoire_custom_command//\"/\\\"}\"" Enter
     fi
-
     tmux new-window -d -t "$current_session" -n "$shpell_name" -c "$session_dir"
-fi
 
-if [[ -n "$window_exists" ]]; then
+else # window already exists in $current_session
     tmux swap-window -s "$current_session:$shpell_name" -t "$grimoire_session:$shpell_name"
 
-    # Get pane info for child process checking
-    pane_pid=$(tmux list-panes -t "$grimoire_session:$shpell_name" -F "#{pane_pid}")
-    child_procs=$(pgrep -P "$pane_pid" | wc -l)
+    # Skip all replay/idle probing unless we actually need to replay a command
+    if [[ $replay_flag == "--replay" && -n $grimoire_custom_command ]]; then
+        # Cheaper "idle-ish" check: current pane command is a shell?
+        # - one tmux call instead of pgrep+wc. No extra processes.
+        pane_cmd=$(tmux list-panes -t "$grimoire_session:$shpell_name" -F "#{pane_current_command}" | head -n1)
+        case "$pane_cmd" in
+            bash|zsh|fish) is_idle=1 ;;
+            *) is_idle=0 ;;
+        esac
 
-    if (( child_procs == 0 )); then
-        is_idle=true
-    else
-        is_idle=false
-    fi
-
-    if [[ $replay_flag == "--replay" && -n $grimoire_custom_command && $is_idle == true ]]; then
-        tmux send-keys -t "$grimoire_session:$shpell_name" "clear; bash -c \"${grimoire_custom_command//\"/\\\"}\"" Enter
+        if [[ $is_idle -eq 1 ]]; then
+            tmux send-keys -t "$grimoire_session:$shpell_name" \
+                "clear; bash -c \"${grimoire_custom_command//\"/\\\"}\"" Enter
+        fi
     fi
 fi
 
-tmux set-option -g mouse off
-tmux display-popup \
+original_mouse_setting=$(tmux show-option -gqv mouse)
+
+# --- Single batched tmux client invocation ---
+tmux \
+    set-option -t "$current_session" mouse off \; \
+    display-popup \
     -E \
     -d "$session_dir" \
     -x "$grimoire_x" \
@@ -95,6 +125,6 @@ tmux display-popup \
     -b "rounded" \
     -S "fg=$grimoire_window_color" \
     -T "$popup_title" \
-    "tmux attach-session -t '$grimoire_session' \; select-window -t '$shpell_name'"
-
-tmux set-option -g mouse "$original_mouse_setting"
+    "tmux select-window -t '$shpell_name' \; \
+    attach-session -t '$grimoire_session' \; \
+    run-shell 'tmux set-option -t \"$current_session\" mouse \"$original_mouse_setting\"'"


### PR DESCRIPTION
This PR batches option lookups and commands into single tmux client calls, cutting per-invocation IPC round-trips and subprocesses.

### How much faster (IPC saved)

Overall, this reduces tmux IPC round-trips by 75–80 %, making shpell casting and popup spawning noticeably faster and smoother. We save a total of **~34 IPC calls per typical use** (no custom overrides, no replay), with higher savings when overrides/commands are used.

- **grimoire.tmux:** 9 calls saved (~12 -> 3)
- **shpell (standard):** 13 calls saved (~18 -> 5)
- **ephemeral_shpell:** 12 calls saved (~15 -> 3)

> With per-shpell overrides and/or replay/custom commands, savings increase to:
> - **shpell:** up to ~15 saved
> - **ephemeral_shpell:** up to ~16 saved