### PR TITLE
feat: add osc52 support to shpell sessions

### DIFF
--- a/bin/osc52-copy
+++ b/bin/osc52-copy
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Route OSC52 clipboard escape to the real terminal PTY
+# stdin: piped selection from copy-pipe-and-cancel
+PTY=$(tmux list-clients -F '#{client_tty} #{session_name}' \
+    | grep -Ev '_shpell-session|_ephemeral-shpell-session' \
+    | head -1 | cut -d' ' -f1)
+[ -z "$PTY" ] && exit 0
+printf '\033]52;c;%s\007' "$(base64 | tr -d '\n')" > "$PTY"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,6 +26,16 @@ set -g @grimoire-height '30%'         # Height as percentage
 # Position
 set -g @grimoire-position 'bottom-center'  # See position options below
 ```
+
+### Clipboard
+
+OSC52 clipboard support is enabled by default. Copied text inside shpells is routed to your system clipboard through the terminal, even over SSH.
+
+```tmux
+# Disable if it causes issues with your terminal
+set -g @grimoire-osc52 'off'
+```
+
 ---
 ## Position Options
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -15,10 +15,15 @@ The script will:
 - Include example custom shpells as comments
 - Provide clear next steps
 
---- 
+---
 ## Manual Installation
 
-### With TPM (Tmux Plugin Manager)
+<details>
+<summary>With Plugin Manager</summary>
+
+### TPM (Tmux Plugin Manager)
+
+The most known, although unmaintained https://github.com/tmux-plugins/tpm
 
 1. Add to your `~/.tmux.conf`:
 
@@ -35,7 +40,27 @@ set -g @plugin 'navahas/tmux-grimoire'
 tmux source-file ~/.tmux.conf
 ```
 
-### Without TPM
+### Plux (TPM in Rust)
+
+For rust lovers. https://github.com/nfejzic/plux
+
+1. Add to your `~/.config/tmux/plux.toml`:
+
+```toml
+[plugins]
+tmux-grimoire = "https://github.com/navahas/tmux-grimoire"
+```
+
+2. Reload tmux configuration and it will update all plugins:
+
+```bash
+tmux source-file ~/.tmux.conf
+```
+
+</details>
+
+<details>
+<summary>Without Plugin Manager</summary>
 
 1. Clone the repository:
 
@@ -54,6 +79,8 @@ run-shell ~/.tmux/plugins/tmux-grimoire/grimoire.tmux
 ```bash
 tmux source-file ~/.tmux.conf
 ```
+
+</details>
 
 ---
 ## Verifying Installation

--- a/grimoire.tmux
+++ b/grimoire.tmux
@@ -35,7 +35,8 @@ while IFS= read -r line; do
     ((i++))
 done < <(tmux display-message -p '#{?@grimoire-key,#{@grimoire-key},}
 #{?@ephemeral-grimoire-key,#{@ephemeral-grimoire-key},}
-#{?@grimoire-kill-key,#{@grimoire-kill-key},}')
+#{?@grimoire-kill-key,#{@grimoire-kill-key},}
+#{?@grimoire-osc52,#{@grimoire-osc52},}')
 
 # User-configurable keybindings
 # set -g @grimoire-key ''
@@ -44,6 +45,7 @@ done < <(tmux display-message -p '#{?@grimoire-key,#{@grimoire-key},}
 grimoire_key=${opts[0]}
 ephemeral_grimoire_key=${opts[1]}
 grimoire_kill_key=${opts[2]}
+grimoire_osc52=${opts[3]}
 
 # Extend tmux PATH with plugin bin/ directory (parameter expansion avoids subprocess overhead)
 env_line=$(tmux show-environment -g PATH 2>/dev/null || true)
@@ -75,3 +77,12 @@ tmux \
     set -g @shpell-grimoire-width "45%" \; \
     set -g @shpell-grimoire-height "55%" \; \
     set -g @shpell-grimoire-position "top-center"
+
+# OSC52 clipboard: pipe copied text to the real terminal PTY (on by default)
+if [[ "$grimoire_osc52" != "off" ]]; then
+    osc52="$PLUGIN_DIR/bin/osc52-copy"
+    tmux \
+        bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "$osc52" \; \
+        bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "$osc52" \; \
+        bind-key -T copy-mode M-w send-keys -X copy-pipe-and-cancel "$osc52"
+fi


### PR DESCRIPTION
While using the plugin over SSH, I realized the clipboard was not working properly.

Clipboard capability in a PTY is enabled through the OSC52 escape sequence, which works even over remote SSH since we are just sending raw bytes that your terminal interprets.

This plugin creates a temporary tmux session for shpells, meaning a new PTY. Locally, OSC52 isn't necessary since clipboard tools work in any nested session, it's tmux talking to your OS directly.

But for remote sessions we don't own the OS. Instead, we're given a PTY instance by the SSH daemon. So we need to ensure the OSC52 sequence reaches the PTY that was assigned to the SSH connection, not the plugin's session inner PTY.

The new script in bin/osc52-copy wraps the copied bytes in an OSC52 sequence and writes them to the parent PTY, the main tmux client's terminal.