### PR TITLE
fix: automatic-rename breaks shpell window swap

### DIFF
--- a/scripts/shpell.sh
+++ b/scripts/shpell.sh
@@ -110,7 +110,8 @@ if [[ -z "$window_exists" ]]; then # window does not exist yet in $current_sessi
             "clear; bash -c \"${grimoire_custom_command//\"/\\\"}\"" Enter
     fi
     tmux new-window -d -t "$current_session:" -n "$shpell_name" -c "$session_dir" \; \
-        set-option -w -t "$current_session:$shpell_name" automatic-rename off
+        set-option -w -t "$current_session:$shpell_name" automatic-rename off \; \
+        set-option -wq -t "$current_session:$shpell_name" @tmux_window_name_enabled 0
 
 else # window already exists in $current_session
     tmux swap-window -s "$current_session:$shpell_name" -t "$grimoire_session:$shpell_name"

--- a/scripts/shpell.sh
+++ b/scripts/shpell.sh
@@ -97,6 +97,7 @@ done < <(tmux list-windows -t "$current_session:" -F '#{window_name}' 2>/dev/nul
 # them sequentially and atomically: one process, one round-trip.
 TMUX='' tmux new-session -d -s "$grimoire_session" -n "$shpell_name" -c "$session_dir" \; \
     set-option -t "$grimoire_session" status off \; \
+    set-option -w -t "$grimoire_session:$shpell_name" automatic-rename off \; \
     set-hook -u -t "$grimoire_session" client-detached \; \
     set-hook -t "$grimoire_session" client-detached \
     "run-shell 'tmux swap-window -s \"$grimoire_session:$shpell_name\" \
@@ -108,7 +109,8 @@ if [[ -z "$window_exists" ]]; then # window does not exist yet in $current_sessi
         tmux send-keys -t "$grimoire_session:$shpell_name" \
             "clear; bash -c \"${grimoire_custom_command//\"/\\\"}\"" Enter
     fi
-    tmux new-window -d -t "$current_session:" -n "$shpell_name" -c "$session_dir"
+    tmux new-window -d -t "$current_session:" -n "$shpell_name" -c "$session_dir" \; \
+        set-option -w -t "$current_session:$shpell_name" automatic-rename off
 
 else # window already exists in $current_session
     tmux swap-window -s "$current_session:$shpell_name" -t "$grimoire_session:$shpell_name"


### PR DESCRIPTION
## Summary

- When `automatic-rename` is enabled globally (or via a plugin like `tmux-window-name`), tmux renames the placeholder window created by `shpell.sh` (e.g., from `main` to `zsh`). This causes the `client-detached` hook's `swap-window` command to fail silently, since it references the original window name.
- As a result, `kill-session` destroys the popup session along with the user's shell state. Reopening the shpell always starts fresh in the source directory instead of preserving the previous working directory.
- Fix: disable `automatic-rename` on both the `_shpell-session` window and the placeholder window in the parent session, and set `@tmux_window_name_enabled 0` on the placeholder to prevent the `tmux-window-name` plugin from re-enabling `automatic-rename` via its `rename_window()` function.

## Steps to reproduce

1. Have `set-option -g automatic-rename on` in tmux config (or a window-renaming plugin like `tmux-window-name`)
2. `prefix + f` to open a shpell
3. `cd /tmp` (or any different directory)
4. `prefix + f` to close
5. `prefix + f` to reopen — the shpell opens in the **original** directory, not `/tmp`

## Test plan

- [ ] Verify shpell preserves working directory across toggle with `automatic-rename on`
- [ ] Verify shpell works normally with `automatic-rename off`
- [ ] Verify custom named shpells also preserve state
- [ ] Verify compatibility with `tmux-window-name` plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)